### PR TITLE
workaround for pulp_tasks when task is the "task" String

### DIFF
--- a/blame_foreman-task_execution.py
+++ b/blame_foreman-task_execution.py
@@ -201,6 +201,8 @@ with open(dynflow_actions_fname, newline='') as _file:
         # pulp tasks
         if 'pulp_tasks' in data:
             for task in data['pulp_tasks']:
+                if task == "task":
+                    continue
                 if task.keys() >= {'pulp_created', 'started_at', 'finished_at'}:
                     process_external_task(step_id, 'pulp',
                                           task['pulp_created'][:23],


### PR DESCRIPTION
$ grep 019654da-2078-7ce5-af3a-b0c7ee737b17 -rn sos_commands/
sos_commands/foreman/dynflow_actions:35822:1701a073-015b-49c3-9d01-6f9313853015,9,,2,Actions::Pulp3::OrphanCleanup::PurgeCompletedTasks,15,16,,,"{""current_location_id"":null,""current_organization_id"":null,""current_request_id"":null,""current_timezone"":""UTC"",""current_user_id"":1,""remote_cp_user"":""admin"",""remote_user"":""admin"",""smart_proxy_id"":35}","{""pulp_tasks"":{""task"":""/pulp/api/v3/tasks/019654da-2078-7ce5-af3a-b0c7ee737b17/""}}"